### PR TITLE
Update fmt library version

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -21,7 +21,7 @@ set(FMT_SYSTEM_HEADERS
 FetchContent_Declare(
   fmt
   GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-  GIT_TAG 11.0.2
+  GIT_TAG 11.2.0
   GIT_SHALLOW ON
   ${find_pkg_args})
 


### PR DESCRIPTION
Update the fmt library to version 11.2.0. Otherwise there may be a compilation error about the missing `<algorithm>` head.